### PR TITLE
feat: 공개설정 조회

### DIFF
--- a/src/Screens/Setting/PrivacySetting.js
+++ b/src/Screens/Setting/PrivacySetting.js
@@ -10,7 +10,7 @@ import {
 import { useNavigation } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { updatePrivacySetting, getUserPrivacySetting } from '../../config/api';
+import { updatePrivacySetting, getUserInfo } from '../../config/api';
 
 export default function PrivacySetting() {
   const navigation = useNavigation();
@@ -54,11 +54,28 @@ export default function PrivacySetting() {
         return;
       }
 
-      // TODO: API 구현 후 현재 설정 조회
-      // const result = await getUserPrivacySetting(userToken);
+      // 사용자 정보 조회로 현재 공개설정 가져오기
+      const userInfo = await getUserInfo(userToken);
+      console.log('사용자 정보 조회 완료:', userInfo);
       
-      // 임시로 기본값 설정 (API 구현 전까지)
-      setCurrentSetting('open');
+      // 공개설정 상태 설정
+      if (userInfo.privacy_settings) {
+        console.log('privacy_settings 필드 발견:', userInfo.privacy_settings);
+        setCurrentSetting(userInfo.privacy_settings);
+      } else if (userInfo.privacy_setting) {
+        console.log('privacy_setting 필드 발견:', userInfo.privacy_setting);
+        setCurrentSetting(userInfo.privacy_setting);
+      } else if (userInfo.is_public !== undefined) {
+        console.log('is_public 필드 발견:', userInfo.is_public);
+        setCurrentSetting(userInfo.is_public ? 'open' : 'closed');
+      } else if (userInfo.privacy) {
+        console.log('privacy 필드 발견:', userInfo.privacy);
+        setCurrentSetting(userInfo.privacy);
+      } else {
+        console.log('공개설정 관련 필드를 찾을 수 없음');
+        console.log('사용 가능한 필드들:', Object.keys(userInfo));
+        setCurrentSetting('open'); // 기본값
+      }
     } catch (error) {
       console.error('공개설정 조회 오류:', error);
       setCurrentSetting('open');

--- a/src/Screens/Setting/SettingsHome.js
+++ b/src/Screens/Setting/SettingsHome.js
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import {
   View,
   Text,
@@ -8,16 +8,79 @@ import {
   Dimensions,
   Alert,
 } from 'react-native';
-import { useNavigation } from '@react-navigation/native';
+import { useNavigation, useFocusEffect } from '@react-navigation/native';
 import { Ionicons } from '@expo/vector-icons';
 import AsyncStorage from '@react-native-async-storage/async-storage';
-import { deleteAccount } from '../../config/api';
+import { deleteAccount, getUserInfo } from '../../config/api';
 
 const { width, height } = Dimensions.get('window');
 
 export default function SettingsHome() {
   const navigation = useNavigation();
   const [isNotificationEnabled, setIsNotificationEnabled] = useState(false);
+  const [currentPrivacySetting, setCurrentPrivacySetting] = useState('open');
+  const [isLoading, setIsLoading] = useState(true);
+
+  // 사용자 정보 조회
+  const fetchUserInfo = async () => {
+    try {
+      const userToken = await AsyncStorage.getItem('userToken');
+      if (userToken) {
+        const userInfo = await getUserInfo(userToken);
+        console.log('사용자 정보 조회 완료:', userInfo);
+        console.log('전체 응답 키들:', Object.keys(userInfo));
+        
+        // 공개설정 상태 설정
+        if (userInfo.privacy_settings) {
+          console.log('privacy_settings 필드 발견:', userInfo.privacy_settings);
+          setCurrentPrivacySetting(userInfo.privacy_settings);
+        } else if (userInfo.privacy_setting) {
+          console.log('privacy_setting 필드 발견:', userInfo.privacy_setting);
+          setCurrentPrivacySetting(userInfo.privacy_setting);
+        } else if (userInfo.is_public !== undefined) {
+          console.log('is_public 필드 발견:', userInfo.is_public);
+          setCurrentPrivacySetting(userInfo.is_public ? 'open' : 'closed');
+        } else if (userInfo.privacy) {
+          console.log('privacy 필드 발견:', userInfo.privacy);
+          setCurrentPrivacySetting(userInfo.privacy);
+        } else {
+          console.log('공개설정 관련 필드를 찾을 수 없음');
+          console.log('사용 가능한 필드들:', Object.keys(userInfo));
+        }
+      }
+    } catch (error) {
+      console.error('❌ 사용자 정보 조회 실패:', error);
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchUserInfo();
+  }, []);
+
+  // 화면에 포커스가 올 때마다 사용자 정보 새로 조회
+  useFocusEffect(
+    React.useCallback(() => {
+      fetchUserInfo();
+    }, [])
+  );
+
+  // 공개설정 텍스트 변환
+  const getPrivacyText = (setting) => {
+    console.log('공개설정 변환:', setting);
+    switch (setting) {
+      case 'open':
+        return '전체 공개';
+      case 'semi':
+        return '일부 공개';
+      case 'closed':
+        return '비공개';
+      default:
+        console.log('알 수 없는 공개설정:', setting);
+        return '전체 공개';
+    }
+  };
 
   // 로그아웃 함수
   const handleLogout = async () => {
@@ -121,7 +184,14 @@ export default function SettingsHome() {
         style={styles.boxButton}
         onPress={() => navigation.navigate('PrivacySetting')}
       >
-        <Text style={styles.boxText}>공개설정 변경</Text>
+        <View style={styles.settingRow}>
+          <Text style={styles.boxText}>공개설정 변경</Text>
+          {!isLoading && (
+            <Text style={styles.currentSettingText}>
+              {getPrivacyText(currentPrivacySetting)}
+            </Text>
+          )}
+        </View>
       </TouchableOpacity>
 
       {/* 알림기능 */}
@@ -184,6 +254,11 @@ const styles = StyleSheet.create({
     justifyContent: 'space-between',
     alignItems: 'center',
   },
+  settingRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
   boxText: {
     fontSize: 15,
     fontWeight: '500',
@@ -192,6 +267,11 @@ const styles = StyleSheet.create({
     fontSize: 12,
     color: '#555',
     marginTop: 8,
+  },
+  currentSettingText: {
+    fontSize: 13,
+    color: '#666',
+    fontWeight: '400',
   },
   logoutButton: {
     width: '100%',

--- a/src/config/api.js
+++ b/src/config/api.js
@@ -898,3 +898,32 @@ export const getUserPrivacySetting = async (userToken) => {
     throw error;
   }
 }; 
+
+// 사용자 정보 조회 함수
+export const getUserInfo = async (userToken = null) => {
+  const config = getApiConfig();
+  
+  try {
+    const headers = { 'Content-Type': 'application/json' };
+    if (userToken) {
+      headers['Authorization'] = `Bearer ${userToken}`;
+    }
+    
+    const response = await fetch(`${config.baseURL}/auth/me`, {
+      method: 'GET',
+      headers
+    });
+    
+    if (!response.ok) {
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+    
+    const result = await response.json();
+    console.log('✅ 사용자 정보 조회 성공:', result);
+    return result;
+  } catch (error) {
+    console.error('❌ 사용자 정보 조회 실패:', error.message);
+    console.error('🔗 API 엔드포인트:', `${config.baseURL}/auth/me`);
+    throw error;
+  }
+}; 


### PR DESCRIPTION
## 🔀 PR 유형
- [ ] FIX (버그 수정)
- [x] FEAT (신규 기능)

## 📌 PR 목적
- 공개설정 조회

## 📝 주요 변경 사항
- SettingsHome.js에 사용자 현재 공개설정 표시 기능 추가
  - getUserInfo API를 사용하여 /api/auth/me 엔드포인트로 사용자 정보 조회
  - privacy_settings, privacy_setting, is_public, privacy 필드 순으로 공개설정 파싱
  - 공개설정 변경 버튼 옆에 현재 설정 상태 표시

- PrivacySetting.js에 현재 공개설정 표시 기능 추가
  - 화면 진입 시 사용자 현재 공개설정 자동 로드
  - getUserInfo API를 사용하여 실시간 공개설정 상태 반영

## ✅ 체크리스트
- [ ] 동일 상황에서 재현되지 않음 확인  
- [x] 단위 테스트/수동 테스트 통과  
- [ ] 문서(README 등) 업데이트  
- [x] 스크린샷/동영상 첨부 (필요 시)  


https://github.com/user-attachments/assets/c1a8f986-ee43-4433-b16a-7ef8cc5a6b70



## 🔍 검토 요청
- 리뷰어: @PokingTeemo  
